### PR TITLE
Make Document.fragment and Document.save methods use correct list of widgets.

### DIFF
--- a/bokeh/src/main/scala/Document.scala
+++ b/bokeh/src/main/scala/Document.scala
@@ -16,10 +16,10 @@ class Document(objs: Widget*) {
         objects ++= objs
     }
 
-    def fragment(resources: Resources): HTMLFragment = HTMLFragmentWriter(objs.toList, resources).write()
+    def fragment(resources: Resources): HTMLFragment = HTMLFragmentWriter(objects.toList, resources).write()
     def fragment(): HTMLFragment = fragment(Resources.default)
 
-    def save(file: File, resources: Resources): HTMLFile = HTMLFileWriter(objs.toList, resources).write(file)
+    def save(file: File, resources: Resources): HTMLFile = HTMLFileWriter(objects.toList, resources).write(file)
     def save(file: File): HTMLFile = save(file, Resources.default)
 
     def save(path: String, resources: Resources): HTMLFile = save(new File(path), resources)


### PR DESCRIPTION
Current implementation of `Document.fragment` and `Document.save` uses `objs` variable as widgets list, which comes from ctor of `Document` class and makes `Document.add` method unusable.

This PR makes `fragment`, `save` and `add` methods work as expected.